### PR TITLE
fix: properly fail job on connection errors

### DIFF
--- a/src/file_manager.py
+++ b/src/file_manager.py
@@ -63,4 +63,4 @@ class FileManager:
 
         except Exception as e:
             logging.error("Failed to save data to CSV: %s", str(e))
-            return False
+            raise


### PR DESCRIPTION
## Summary

Fixes a bug where the component would silently complete with no data when unable to connect to the external API (e.g., DNS resolution failure), instead of properly failing the job.

**Root cause:** Two issues were identified from job 152277634 logs:
1. In `api_client.py`, the `response` variable was accessed in the exception handler before it was assigned (when DNS fails, the exception occurs before `response = self.transport.post(...)` completes)
2. In `file_manager.py`, exceptions during CSV writing were caught and converted to `return False`, masking the actual failure

**Changes:**
- Initialize `response = None` before the retry loop and only attempt SOAP fault parsing when `response` is not None
- Re-raise exceptions in `save_to_csv()` instead of returning `False`

## Review & Testing Checklist for Human

- [ ] **Verify retry logic still works**: The "already logged in" retry case (`již v systému přihlášen`) should still trigger retries - confirm the nested try-except doesn't break this
- [ ] **Test with actual DNS failure**: Run the component against an unreachable host to confirm the job now fails with a proper error instead of completing silently
- [ ] **Check caller handling**: Verify that `component.py` properly handles the exception now raised by `save_to_csv()` (it should propagate up and exit with code 2)

### Notes

- No unit tests were added for this fix - consider adding a test that mocks a connection failure
- The original error from Datadog: `"cannot access local variable 'response' where it is not associated with a value"`

Link to Devin run: https://app.devin.ai/sessions/baa3d13a228d4cdba6d839dfd7478137
Requested by: zdenek.srotyr@keboola.com (@ZdenekSrotyr)